### PR TITLE
fix: adapt env vars created via bm-operations

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,11 +11,11 @@ on:
 
 env:
   SEGMENT: loc00
-  DATABASE_HOST: localhost
-  DATABASE_PORT: 5432
-  DATABASE_USER: postgres
-  DATABASE_PASSWORD: postgres
-  DATABASE_NAME: test_licensing
+  DB_HOST: localhost
+  DB_PORT: 5432
+  DB_USER: postgres
+  DB_PASSWORD: postgres
+  DB_NAME: test_licensing
 
 jobs:
   pytest:

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Create a 'dotenv' file:
 Create a file named '.env' in the root folder of the app and provide your database paramaters and credentials like so:
 
 ```
-DATABASE_USER=<<your 'postgres' user name (root user of the RDBMS)>>
-DATABASE_PASSWORD=<<your 'postgres' users (root user of the RDBMS) password>>
-DATABASE_HOST="localhost"
-DATABASE_PORT="5432"
-DATABASE_NAME=<<the name of the 'license-manager' database you will create in the following step (licm)>>
+DB_USER=<<your 'postgres' user name (root user of the RDBMS)>>
+DB_PASSWORD=<<your 'postgres' users (root user of the RDBMS) password>>
+DB_HOST="localhost"
+DB_PORT="5432"
+DB_NAME=<<the name of the 'license-manager' database you will create in the following step (licm)>>
 ```
 Before you can start the application, you have to install a database. Please create a database manually
 on your local postgreSQL database using the SQL query

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,11 @@ services:
       - 8002:8000
     environment:
       - SEGMENT=loc00
-      - DATABASE_HOST=postgres
-      - DATABASE_PORT=5432
-      - DATABASE_USER=licm
-      - DATABASE_PASSWORD=licm
-      - DATABASE_NAME=licm
+      - DB_HOST=postgres
+      - DB_PORT=5432
+      - DB_USER=licm
+      - DB_PASSWORD=licm
+      - DB_NAME=licm
       - LOG_FORMAT=console
       - LOG_LEVEL=DEBUG
     depends_on:

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -5,9 +5,10 @@ generatorOptions:
   disableNameSuffixHash: true
 
 secretGenerator:
-  # - name: loc00-licensing-application-secret
-  #   envs:
-  #     - loc00/licensing-application-secret.env
+  - name: loc00-application-secret
+    namespace: "licensing"
+    envs:
+      - loc00/application-secret.env
   - name: loc00-tls-secret
     namespace: "licensing"
     type: "kubernetes.io/tls"

--- a/k8s/lib/charts/licensing.ts
+++ b/k8s/lib/charts/licensing.ts
@@ -30,11 +30,11 @@ export type LicensingChartProps = ChartProps & {
    * Name of the secret containing Postgres credentials
    *
    * Required keys:
-   * - DATABASE_HOST
-   * - DATABASE_PORT
-   * - DATABASE_USER
-   * - DATABASE_PASSWORD
-   * - DATABASE_NAME
+   * - DB_HOST
+   * - DB_PORT
+   * - DB_USER
+   * - DB_PASSWORD
+   * - DB_NAME
    */
   postgresSecret: string;
   /**
@@ -141,12 +141,12 @@ export class LicensingChart extends Chart {
       },
       ...(applicationSecret
         ? [
-            {
-              secretRef: {
-                name: applicationSecret,
-              },
+          {
+            secretRef: {
+              name: applicationSecret,
             },
-          ]
+          },
+        ]
         : []),
     ];
 
@@ -171,7 +171,7 @@ export class LicensingChart extends Chart {
           command: [
             "sh",
             "-c",
-            "until pg_isready --host ${DATABASE_HOST}; do sleep 1; done",
+            "until pg_isready --host ${DB_HOST}; do sleep 1; done",
           ],
           envFrom: applicationEnv,
           resources: {

--- a/k8s/lib/charts/postgres.ts
+++ b/k8s/lib/charts/postgres.ts
@@ -19,11 +19,11 @@ export class PostgresChart extends Chart {
    * Secret with Postgres credentials
    *
    * keys:
-   * - DATABASE_HOST
-   * - DATABASE_PORT
-   * - DATABASE_USER
-   * - DATABASE_PASSWORD
-   * - DATABASE_NAME
+   * - DB_HOST
+   * - DB_PORT
+   * - DB_USER
+   * - DB_PASSWORD
+   * - DB_NAME
    * - POSTGRES_PASSWORD
    */
   readonly secret: ISecret;
@@ -37,10 +37,10 @@ export class PostgresChart extends Chart {
         namespace,
       },
       stringData: {
-        DATABASE_PORT: "5432",
-        DATABASE_USER: "postgres",
-        DATABASE_PASSWORD: "postgres",
-        DATABASE_NAME: "postgres",
+        DB_PORT: "5432",
+        DB_USER: "postgres",
+        DB_PASSWORD: "postgres",
+        DB_NAME: "postgres",
         POSTGRES_PASSWORD: "postgres",
         POSTGRES_USER: "postgres",
         POSTGRES_DB: "postgres",
@@ -139,8 +139,8 @@ export class PostgresChart extends Chart {
       },
     });
 
-    pgSecret.addStringData("DATABASE_HOST", pgService.name);
-    // pgSecret.addStringData("DATABASE_PORT", "5432");
+    pgSecret.addStringData("DB_HOST", pgService.name);
+    pgSecret.addStringData("DB_PORT", "5432");
     this.secret = pgSecret;
   }
 }

--- a/k8s/lib/config.ts
+++ b/k8s/lib/config.ts
@@ -11,14 +11,14 @@ import {
  * Information to go in secrets
  *
  * DB related:
- * - DATABASE_HOST
- * - DATABASE_PORT
- * - DATABASE_USER
- * - DATABASE_PASSWORD
- * - DATABASE_NAME
+ * - DB_HOST
+ * - DB_PORT
+ * - DB_USER
+ * - DB_PASSWORD
+ * - DB_NAME
  *
  * Application related:
- *
+ * - APM_SECRET_TOKEN
  */
 
 /**
@@ -29,10 +29,6 @@ export const APPLICATION_CONFIG: { [key: string]: ApplicationConfig } = {
     SEGMENT: Segment.LOC00,
     LOG_FORMAT: "console",
     LOG_LEVEL: LogLevel.DEBUG,
-    DATABASE_USER: "postgres",
-    DATABASE_HOST: "localhost",
-    DATABASE_PORT: "5432",
-    DATABASE_NAME: "licm",
     APM_URL: "",
     APM_ENABLED: false,
     APM_TRANSACTION_SAMPLE_RATE: "0.1",
@@ -41,10 +37,6 @@ export const APPLICATION_CONFIG: { [key: string]: ApplicationConfig } = {
     SEGMENT: Segment.DEV00,
     LOG_FORMAT: "json",
     LOG_LEVEL: LogLevel.DEBUG,
-    DATABASE_USER: "postgres",
-    DATABASE_HOST: "localhost",
-    DATABASE_PORT: "5432",
-    DATABASE_NAME: "licm",
     APM_URL: "https://apm.bettermarks.com",
     APM_ENABLED: true,
     APM_TRANSACTION_SAMPLE_RATE: "0.1",
@@ -53,10 +45,6 @@ export const APPLICATION_CONFIG: { [key: string]: ApplicationConfig } = {
     SEGMENT: Segment.CI00,
     LOG_FORMAT: "json",
     LOG_LEVEL: LogLevel.DEBUG,
-    DATABASE_USER: "postgres",
-    DATABASE_HOST: "localhost",
-    DATABASE_PORT: "5432",
-    DATABASE_NAME: "licm",
     APM_URL: "https://apm.bettermarks.com",
     APM_ENABLED: true,
     APM_TRANSACTION_SAMPLE_RATE: "0.1",
@@ -65,10 +53,6 @@ export const APPLICATION_CONFIG: { [key: string]: ApplicationConfig } = {
     SEGMENT: Segment.PRO00,
     LOG_FORMAT: "json",
     LOG_LEVEL: LogLevel.INFO,
-    DATABASE_USER: "postgres",
-    DATABASE_HOST: "localhost",
-    DATABASE_PORT: "5432",
-    DATABASE_NAME: "licm",
     APM_URL: "https://apm.bettermarks.com",
     APM_ENABLED: true,
     APM_TRANSACTION_SAMPLE_RATE: "0.1",

--- a/k8s/lib/constants.ts
+++ b/k8s/lib/constants.ts
@@ -6,17 +6,17 @@ export const APP_NODE_POOL_LABELS: NodeSelector = {
 
 /**
  * Name of the secret which is used by service chart to look up application secret.
- * This secret is created by AWS Secrets helper in bm-operations project. https://github.com/bettermarks/bm-operations/blob/master/cdk8s/main.ts
+ * This secret is created by AWS Secrets helper in bm-operations project. https://github.com/bettermarks/bm-operations/blob/master/cdk8s/apps/licensing.ts
  */
-export const APPLICATION_SECRET = "licensing-application-secret";
+export const APPLICATION_SECRET = "licensing-secret";
 /**
  * Name of the secret which is used by service chart to look up Postgres DB credentials.
- * This secret is created  by AWS Secrets helper in bm-operations project. https://github.com/bettermarks/bm-operations/blob/master/cdk8s/main.ts
+ * This secret is created  by AWS Secrets helper in bm-operations project. https://github.com/bettermarks/bm-operations/blob/master/cdk8s/apps/licensing.ts
  */
 export const POSTGRES_SECRET = "licensing-postgres-secret";
 /**
  * Name of the secret used by Service Account to pull image from AWS ECR registry.
- * This secret is created by AWS Registry Helper Cron. https://github.com/bettermarks/bm-operations/blob/master/cdk8s/main.ts
+ * This secret is created by AWS Registry Helper Cron. https://github.com/bettermarks/bm-operations/blob/master/cdk8s/apps/licensing.ts
  */
 export const REGISTRY_CREDENTIALS = "registry-credentials";
 /**

--- a/k8s/lib/types.ts
+++ b/k8s/lib/types.ts
@@ -33,10 +33,6 @@ export type ApplicationConfig = {
   SEGMENT: string,
   LOG_FORMAT: string;
   LOG_LEVEL: LogLevel;
-  DATABASE_USER: string;
-  DATABASE_HOST: string;
-  DATABASE_PORT: string;
-  DATABASE_NAME: string;
   APM_URL: string,
   APM_ENABLED: boolean,
   APM_TRANSACTION_SAMPLE_RATE: string,

--- a/k8s/loc00/application-secret.env
+++ b/k8s/loc00/application-secret.env
@@ -1,0 +1,1 @@
+APM_SECRET_TOKEN=""

--- a/k8s/main.ts
+++ b/k8s/main.ts
@@ -31,6 +31,7 @@ if (SEGMENT === Segment.LOC00) {
     image: IMAGE_NAME,
     segment: SEGMENT,
     postgresSecret: pgChart.secret.name,
+    applicationSecret: "loc00-application-secret",
     imagePullSecrets: [],
   });
   new IngressNginxChart(app, "ingress-nginx", {

--- a/k8s/package-lock.json
+++ b/k8s/package-lock.json
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@types/jest": "^26.0.24",
         "@types/node": "^18.11.18",
-        "cdk8s-cli": "^2.1.123",
+        "cdk8s-cli": "^2.1.144",
         "jest": "^26.6.3",
         "ts-jest": "^26.5.6",
         "typescript": "^4.9.4"
@@ -935,9 +935,9 @@
       }
     },
     "node_modules/@jsii/check-node": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.74.0.tgz",
-      "integrity": "sha512-1vNR0eGy8A15A+wlgYFpnjjUtiKLvizZse8THH7UR9Apa9lF68fd3A6ZHiHIu1Rz7PrdH2AoIR4YC8mwqu9e8g==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.77.0.tgz",
+      "integrity": "sha512-kgq4h5SrpIuM9CZ6uZVZ9KrJCPSn6zwz4y60ZEIFMA5aqkBN1n7MhTJglG6I8IaL2uYm7P5kZf6+eGNI+n3tig==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
@@ -948,9 +948,9 @@
       }
     },
     "node_modules/@jsii/spec": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.74.0.tgz",
-      "integrity": "sha512-+Kfh7Xdvt6rmZ/W3OhOQq4iWcoZvvYwbfOm0NB7uF70q20LYaKMvLKaYWPTlxSZTrkScZwHrIFTryLlJ/e/v+w==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.77.0.tgz",
+      "integrity": "sha512-QmwXRREX8W1YOdKHbfu+Tw0rygdCJ2AYcKt7iu56Is2giQ9doyRLKvzywXoKxJjZtj9E7Sp0GdDob8pl8cwmlg==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.12.0"
@@ -1710,9 +1710,9 @@
       }
     },
     "node_modules/cdk8s": {
-      "version": "2.6.36",
-      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.6.36.tgz",
-      "integrity": "sha512-2Fj/oTsuXVsP8W7zQDYcesyu8AOQjvKAdHKyrjzozLAElWCoR75dEb63yYrglJKZrRIgD+ahZEtuzv0MeEMlIA==",
+      "version": "2.7.23",
+      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.7.23.tgz",
+      "integrity": "sha512-mofg+0B6VkIXMbW6yWNW6fxAiiMZMUllRm5MDtWby+WuNEKVVHNmtRXD2CtJrrdZ1HVOUJwF9C5+/h2yJC/XYA==",
       "bundleDependencies": [
         "fast-json-patch",
         "follow-redirects",
@@ -1731,26 +1731,26 @@
       }
     },
     "node_modules/cdk8s-cli": {
-      "version": "2.1.123",
-      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-2.1.123.tgz",
-      "integrity": "sha512-XkHP/3E+QuSuWIB76WTrgLlAZpCrzQXTWhQE6WcppAlVvsChOB3dpTTH34ox5iSW7p+49Yt2C4vxA2NTFTacDA==",
+      "version": "2.1.151",
+      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-2.1.151.tgz",
+      "integrity": "sha512-8JBhczeS5O2XZk3wcY7LlTQ2qR9NsFo1CcK2axfVVvFkq3DI9rHK1CnNrV56Mifigt6yu2PLAIq3ueOxsLPVgQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "^14",
         "ajv": "^8.12.0",
-        "cdk8s": "^2.6.36",
-        "cdk8s-plus-25": "^2.4.7",
-        "codemaker": "^1.74.0",
+        "cdk8s": "^2.7.22",
+        "cdk8s-plus-25": "^2.4.44",
+        "codemaker": "^1.77.0",
         "colors": "1.4.0",
-        "constructs": "^10.1.237",
+        "constructs": "^10.1.269",
         "fs-extra": "^8",
-        "jsii-pacmak": "^1.74.0",
-        "jsii-srcmak": "^0.1.811",
-        "json2jsii": "^0.3.261",
+        "jsii-pacmak": "^1.77.0",
+        "jsii-srcmak": "^0.1.844",
+        "json2jsii": "^0.3.296",
         "semver": "^7.3.8",
         "sscaff": "^1.2.274",
         "table": "^6.8.1",
-        "yaml": "2.0.0-11",
+        "yaml": "2.2.1",
         "yargs": "^15"
       },
       "bin": {
@@ -1815,9 +1815,9 @@
       }
     },
     "node_modules/cdk8s-plus-25": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/cdk8s-plus-25/-/cdk8s-plus-25-2.4.8.tgz",
-      "integrity": "sha512-PnZ1NgS/cAlgmEBvq1liyoGrJZuq3RuAUHr2JZVbjIAsXpv+lxiHv0glXycxGawD1gwXdK1A6YbMYVwFxJUqUA==",
+      "version": "2.4.45",
+      "resolved": "https://registry.npmjs.org/cdk8s-plus-25/-/cdk8s-plus-25-2.4.45.tgz",
+      "integrity": "sha512-wwGNoZ+bw3r/5fNkNh458oFz/RJORwhugRPKjDvo9rTHxAHcrtZAqbpKyFR3Ek1D1+to5CneRIcwsNX6UQ0pQA==",
       "bundleDependencies": [
         "minimatch"
       ],
@@ -1829,8 +1829,8 @@
         "node": ">= 14.17.0"
       },
       "peerDependencies": {
-        "cdk8s": "^2.6.36",
-        "constructs": "^10.1.237"
+        "cdk8s": "^2.7.23",
+        "constructs": "^10.1.270"
       }
     },
     "node_modules/cdk8s-plus-25/node_modules/balanced-match": {
@@ -1838,16 +1838,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/cdk8s-plus-25/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
     },
     "node_modules/cdk8s-plus-25/node_modules/concat-map": {
       "version": "0.0.1",
@@ -1865,6 +1855,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/cdk8s-plus-25/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/cdk8s/node_modules/fast-json-patch": {
@@ -2065,9 +2065,9 @@
       }
     },
     "node_modules/codemaker": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.74.0.tgz",
-      "integrity": "sha512-i6fAyWpXAYN/dd8hvzFPJ7+Yb/a23+BmeCu/lPn0KDpDs/KpNKoz/I3Iq9JD4AL9bMc1b7kBeBV+UF6kS6EMEg==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.77.0.tgz",
+      "integrity": "sha512-XSHAqkXMn5OtcebJLVMFEW9puB+4ZmmChBFspEf62ZeYzs+ggSXEHW9GrjC/ZyX+sfxql6ciJP3z25sSp4VsVQ==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -2202,9 +2202,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.237",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.237.tgz",
-      "integrity": "sha512-Y8HH/d5opBmp97C0BM8Ib24wIbA1nP6xzewnMlRilth/B1p29tvI+bR/o981z7gdgwLdVgs6kBrUXCHg+OQ/tQ==",
+      "version": "10.1.270",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.270.tgz",
+      "integrity": "sha512-EuPb/VI9q0pOy/deaddOIO0RKdJXpBv+qTo7AbYK2dcEq6Kd7PJ8TnDQ5XwotWgB7YaXuTPddIgFDyyIstHcsA==",
       "engines": {
         "node": ">= 14.17.0"
       }
@@ -4196,18 +4196,18 @@
       }
     },
     "node_modules/jsii": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/jsii/-/jsii-1.74.0.tgz",
-      "integrity": "sha512-Y2Y3U2kYOn7yRYD4UrMyq3pJNGIKebEWsjbFjsYiCm+LNqdq9beAh+Ayv7NA4mACSJbWNqTcT/VH7qZMIVBsww==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/jsii/-/jsii-1.77.0.tgz",
+      "integrity": "sha512-3VODnWUhljro1+PmWlTWAEUPxWGWwCOmzOS6EG7l5E1KthurCgQDzhpTySlw80U85mGU9XvDJMcpvwuj3ESrKA==",
       "dev": true,
       "dependencies": {
-        "@jsii/check-node": "1.74.0",
-        "@jsii/spec": "^1.74.0",
+        "@jsii/check-node": "1.77.0",
+        "@jsii/spec": "^1.77.0",
         "case": "^1.6.3",
         "chalk": "^4",
         "fast-deep-equal": "^3.1.3",
         "fs-extra": "^10.1.0",
-        "log4js": "^6.7.1",
+        "log4js": "^6.8.0",
         "semver": "^7.3.8",
         "semver-intersect": "^1.4.0",
         "sort-json": "^2.0.1",
@@ -4223,20 +4223,20 @@
       }
     },
     "node_modules/jsii-pacmak": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.74.0.tgz",
-      "integrity": "sha512-se/HUWjCsaXFGI1K/EGDOHtWbETn4iwm14SuK6LFj5CQu7ZX/aHTBCGFWA3qUwttXaDaBNatmuNQUYSydvKeaA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.77.0.tgz",
+      "integrity": "sha512-mYrITqM/fTiS1rzGFYeIK90/Ab7S39/4wFlBlhVYqqxbeAwiOFS1+zfx2m5RBYGvJMw5rd6S4zoWg6CnK2kpPg==",
       "dev": true,
       "dependencies": {
-        "@jsii/check-node": "1.74.0",
-        "@jsii/spec": "^1.74.0",
+        "@jsii/check-node": "1.77.0",
+        "@jsii/spec": "^1.77.0",
         "clone": "^2.1.2",
-        "codemaker": "^1.74.0",
+        "codemaker": "^1.77.0",
         "commonmark": "^0.30.0",
         "escape-string-regexp": "^4.0.0",
         "fs-extra": "^10.1.0",
-        "jsii-reflect": "^1.74.0",
-        "jsii-rosetta": "^1.74.0",
+        "jsii-reflect": "^1.77.0",
+        "jsii-rosetta": "^1.77.0",
         "semver": "^7.3.8",
         "spdx-license-list": "^6.6.0",
         "xmlbuilder": "^15.1.1",
@@ -4340,16 +4340,16 @@
       }
     },
     "node_modules/jsii-reflect": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.74.0.tgz",
-      "integrity": "sha512-/yt04q5pfnwZZtiHkXxg3svJYI3U77uhbCE/sdcVDoCsRLJhpsI2k+7Py0wls+YXhs6V50jIesw8/YAatfGveg==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.77.0.tgz",
+      "integrity": "sha512-wSEkBxdEjuZHp2qLPpUPFamhppvDBW+vUJi8/VnQlAYJMCOIvQPdj8GVfiMllc+6tir9xIHl8q30PZaanbQpXA==",
       "dev": true,
       "dependencies": {
-        "@jsii/check-node": "1.74.0",
-        "@jsii/spec": "^1.74.0",
+        "@jsii/check-node": "1.77.0",
+        "@jsii/spec": "^1.77.0",
         "chalk": "^4",
         "fs-extra": "^10.1.0",
-        "oo-ascii-tree": "^1.74.0",
+        "oo-ascii-tree": "^1.77.0",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -4450,21 +4450,21 @@
       }
     },
     "node_modules/jsii-rosetta": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-1.74.0.tgz",
-      "integrity": "sha512-dP3c0oJ8XYNKq/OC1v7algTPLXcd9VmhiGQOwVs4R6U9xfo82A3JQ675u3vXXFqBt3OwRXCDL4L9Kk5IwrteyQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-1.77.0.tgz",
+      "integrity": "sha512-gOpK7YxGb64Fwy6zvEpRV3umC3u77HAmltP3kSF/eGPmM04ggTQ17UEfN+XsEO4NXJh1LDniMDyMjOIa3QViBw==",
       "dev": true,
       "dependencies": {
-        "@jsii/check-node": "1.74.0",
-        "@jsii/spec": "1.74.0",
+        "@jsii/check-node": "1.77.0",
+        "@jsii/spec": "1.77.0",
         "@xmldom/xmldom": "^0.8.6",
         "commonmark": "^0.30.0",
         "fast-glob": "^3.2.12",
-        "jsii": "1.74.0",
+        "jsii": "1.77.0",
         "semver": "^7.3.8",
         "semver-intersect": "^1.4.0",
         "typescript": "~3.9.10",
-        "workerpool": "^6.3.1",
+        "workerpool": "^6.4.0",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -4543,14 +4543,14 @@
       }
     },
     "node_modules/jsii-srcmak": {
-      "version": "0.1.811",
-      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.811.tgz",
-      "integrity": "sha512-Q+MI9/AXIIEVVWDT0JXSnR2d/j79V8uMe7gkeuDw3QgDeGa2r1egX5Eo1RCCMFUy1nAQ0O0z3rzVm+nTxJGv4Q==",
+      "version": "0.1.845",
+      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.845.tgz",
+      "integrity": "sha512-6+NImnnkD80q6nYmO+P+lY3qDyLzl2voI3FPVCllnU6z2kEaQqavAONyaBr8BWLXMQMeWtNJmgE+mNfyqPoraQ==",
       "dev": true,
       "dependencies": {
         "fs-extra": "^9.1.0",
-        "jsii": "^1.74.0",
-        "jsii-pacmak": "^1.74.0",
+        "jsii": "^1.77.0",
+        "jsii-pacmak": "^1.77.0",
         "ncp": "^2.0.0",
         "yargs": "^15.4.1"
       },
@@ -4716,9 +4716,9 @@
       "dev": true
     },
     "node_modules/json2jsii": {
-      "version": "0.3.261",
-      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.3.261.tgz",
-      "integrity": "sha512-Ns4vzQyqkyk5uFRzpzSDUacYaKqCVQ0+PaCG9nahSjry24mqXmtBoGdmSFZwz95ImD9PDhwgOhcYoBdsQCgYjQ==",
+      "version": "0.3.297",
+      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.3.297.tgz",
+      "integrity": "sha512-fOFziUye+rompQuBiAtzUkc86pFXGoMB6tLyWhle/O9GvgxwGiwy4VMv6L5/xx79CiKFcuFctW86m4H+9SGKJA==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -4821,16 +4821,16 @@
       "dev": true
     },
     "node_modules/log4js": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.7.1.tgz",
-      "integrity": "sha512-lzbd0Eq1HRdWM2abSD7mk6YIVY0AogGJzb/z+lqzRk+8+XJP+M6L1MS5FUSc3jjGru4dbKjEMJmqlsoYYpuivQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.0.tgz",
+      "integrity": "sha512-sAGxJKqxXFlK+05OlMH6SIDAdvgQHj95EfSDOfkHW6BQUlkz+fZw8PWhydfRHq+0UuWYWR55mVnR+KTnWE2JDA==",
       "dev": true,
       "dependencies": {
         "date-format": "^4.0.14",
         "debug": "^4.3.4",
         "flatted": "^3.2.7",
         "rfdc": "^1.3.0",
-        "streamroller": "^3.1.3"
+        "streamroller": "^3.1.5"
       },
       "engines": {
         "node": ">=8.0"
@@ -5291,9 +5291,9 @@
       }
     },
     "node_modules/oo-ascii-tree": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.74.0.tgz",
-      "integrity": "sha512-tV5BBZhFvALFKY/DMVILN5jDznPRZte0Yoj1hPmbAVGL4VSpsEXx0ZrP8fnFZKbAOyCwWq+PV26n7S5+cP86Xw==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.77.0.tgz",
+      "integrity": "sha512-UQXPEVtecK9FDQxlp5WQ9nVBgS0sq96R9LWE1HBmlS3ZLJRqXh3+kdU7Bxs+qqF+cdWmE9uOggwihBffTpqLrA==",
       "dev": true,
       "engines": {
         "node": ">= 14.6.0"
@@ -6768,9 +6768,9 @@
       }
     },
     "node_modules/streamroller": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.4.tgz",
-      "integrity": "sha512-Ha1Ccw2/N5C/IF8Do6zgNe8F3jQo8MPBnMBGvX0QjNv/I97BcNRzK6/mzOpZHHK7DjMLTI3c7Xw7Y1KvdChkvw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
+      "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
       "dev": true,
       "dependencies": {
         "date-format": "^4.0.14",
@@ -7486,9 +7486,9 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.3.1.tgz",
-      "integrity": "sha512-0x7gJm1rhpn5SPG9NENOxPtbfUZZtK/qOg6gEdSqeDBA3dTeR91RJqSPjccPRCkhNfrnnl/dWxSSj5w9CtdzNA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.4.0.tgz",
+      "integrity": "sha512-i3KR1mQMNwY2wx20ozq2EjISGtQWDIfV56We+yGJ5yDs8jTwQiLLaqHlkBHITlCuJnYlVRmXegxFxZg7gqI++A==",
       "dev": true
     },
     "node_modules/wrap-ansi": {
@@ -7578,12 +7578,12 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.0.0-11",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-11.tgz",
-      "integrity": "sha512-5kGSQrzDyjCk0BLuFfjkoUE9vYcoyrwZIZ+GnpOSM9vhkvPjItYiWJ1jpRSo0aU4QmsoNrFwDT4O7XS2UGcBQg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
       "dev": true,
       "engines": {
-        "node": ">= 12"
+        "node": ">= 14"
       }
     },
     "node_modules/yargs": {

--- a/k8s/tests/licensing-local-chart.test.ts
+++ b/k8s/tests/licensing-local-chart.test.ts
@@ -14,7 +14,7 @@ describe("licensing-local-chart", () => {
       namespace: "dummy-namespace",
       segment: Segment.LOC00,
       postgresSecret: "pgChart.secret.name",
-      applicationSecret: "loc00-licensing-application-secret",
+      applicationSecret: "loc00-application-secret",
     });
     const results = Testing.synth(chart);
     expect(results).toMatchSnapshot();

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,10 +5,12 @@ build:
     - image: bm-licensing
       docker:
         dockerfile: k8s/Dockerfile.dev
+
 deploy:
   kustomize:
     paths:
       - "k8s"
+
 portForward:
   - resourceType: Service
     resourceName: ingress-nginx-controller

--- a/src/licensing/db.py
+++ b/src/licensing/db.py
@@ -19,11 +19,11 @@ def postgres_dsn(
 
 
 DATABASE_DSN = postgres_dsn(
-    settings.database_host,
-    settings.database_port,
-    settings.database_user,
-    settings.database_password,
-    settings.database_name,
+    settings.db_host,
+    settings.db_port,
+    settings.db_user,
+    settings.db_password,
+    settings.db_name,
 )
 
 # SQLAlchemy session

--- a/src/licensing/settings.py
+++ b/src/licensing/settings.py
@@ -8,11 +8,11 @@ log_format: str = config(
 )
 
 # DB settings
-database_user: str = config("DATABASE_USER")
-database_password: str = config("DATABASE_PASSWORD")
-database_host: str = config("DATABASE_HOST")
-database_port: str = config("DATABASE_PORT")
-database_name: str = config("DATABASE_NAME")
+db_user: str = config("DB_USER")
+db_password: str = config("DB_PASSWORD")
+db_host: str = config("DB_HOST")
+db_port: str = config("DB_PORT")
+db_name: str = config("DB_NAME")
 
 segment: str = config("SEGMENT")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -49,13 +49,13 @@ class Class_:
     level: int = 1
 
 
-TEST_DATABASE_NAME = "test_licensing"
+TEST_DB_NAME = "test_licensing"
 TEST_DATABASE_DSN = postgres_dsn(
-    settings.database_host,
-    settings.database_port,
-    settings.database_user,
-    settings.database_password,
-    TEST_DATABASE_NAME,
+    settings.db_host,
+    settings.db_port,
+    settings.db_user,
+    settings.db_password,
+    TEST_DB_NAME,
 )
 
 # we need that for setting up the DB tables ...


### PR DESCRIPTION
# Description

Secrets for licensing charts are defined in ...

AWS secret manager for remote setup
- `licensing/dev00/credentials` (Application secrets)
- `ionos/dev00-pg-cluster-licensing/credentials` (DB secrets)

Inside the project for local setup
- k8s/loc00/application-secret.env (Application secrets)
- k8s/lib/charts/postgres.ts (DB secrets)